### PR TITLE
add: 재사용 가능한 식별자 프로토콜 추가

### DIFF
--- a/iSymbol.xcodeproj/project.pbxproj
+++ b/iSymbol.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		051156142C66620D00230CFE /* ReusableIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051156132C66620D00230CFE /* ReusableIdentifier.swift */; };
 		056F30002C5CB2DD00931302 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F2FFF2C5CB2DD00931302 /* AppDelegate.swift */; };
 		056F30022C5CB2DD00931302 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056F30012C5CB2DD00931302 /* SceneDelegate.swift */; };
 		056F30092C5CB2DF00931302 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 056F30082C5CB2DF00931302 /* Assets.xcassets */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		051156132C66620D00230CFE /* ReusableIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableIdentifier.swift; sourceTree = "<group>"; };
 		056F2FFC2C5CB2DD00931302 /* iSymbol.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iSymbol.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		056F2FFF2C5CB2DD00931302 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		056F30012C5CB2DD00931302 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -46,6 +48,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		051156122C6661F100230CFE /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				051156132C66620D00230CFE /* ReusableIdentifier.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		056F2FF32C5CB2DD00931302 = {
 			isa = PBXGroup;
 			children = (
@@ -131,6 +141,7 @@
 			isa = PBXGroup;
 			children = (
 				056F30242C5CBE2E00931302 /* Base */,
+				051156122C6661F100230CFE /* Extension */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -291,6 +302,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				051156142C66620D00230CFE /* ReusableIdentifier.swift in Sources */,
 				056F301F2C5CB44A00931302 /* BaseViewController.swift in Sources */,
 				056F301A2C5CB3B300931302 /* HomeVC.swift in Sources */,
 				056F301C2C5CB40C00931302 /* HomeView.swift in Sources */,

--- a/iSymbol/Sources/Util/Extension/ReusableIdentifier.swift
+++ b/iSymbol/Sources/Util/Extension/ReusableIdentifier.swift
@@ -1,0 +1,23 @@
+//
+//  ReusableIdentifier.swift
+//  iSymbol
+//
+//  Created by RAFA on 8/9/24.
+//
+
+import UIKit
+
+protocol ReusableIdentifier: AnyObject { }
+
+extension ReusableIdentifier where Self: UIView {
+    
+    static var identifier: String {
+        return String(describing: self)
+    }
+}
+
+extension UITableViewHeaderFooterView: ReusableIdentifier { }
+
+extension UITableViewCell: ReusableIdentifier { }
+
+extension UICollectionReusableView: ReusableIdentifier { }


### PR DESCRIPTION
## 📝 작업 내용 (필수)
- 재사용 가능한 식별자 프로토콜 추가 및 확장자를 통해 사용될 뷰에 채택

## 📷 스크린샷 (선택)


## 📌 참고 사항 (선택)
### 적용 예시
```swift
tableView.do {
    $0.register(
        SuggestionCell.self,
        forCellReuseIdentifier: SuggestionCell.identifier
    )
            
    $0.register(
        HomeHeaderView.self,
        forHeaderFooterViewReuseIdentifier: HomeHeaderView.identifier
    )
            
    $0.register(
        RecommendationBookCell.self,
        forCellReuseIdentifier: RecommendationBookCell.identifier
    )
}
```

## 🎯 관련 이슈 (필수)
- Resolved: #1 
